### PR TITLE
Use bash to execute the build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,4 @@ jobs:
               run: |
                   echo Building docker images
                   ls -R
-                  ./scripts/build_docker_image_ci.sh
+                  bash ./scripts/build_docker_image_ci.sh


### PR DESCRIPTION
Use bash to exectute the build script in the GitHub build workflow.